### PR TITLE
Add 'EnvironmentVariables' to contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 Execute CLI commands from your F# code in F# style!
 
 ### Getting Started
+Get it from Nuget: `dotnet add package Fli`
+
 Just `open Fli` and start ...
 
 For example:
@@ -36,10 +38,19 @@ cli {
 ```
 
 Add a verb to your executing program:
-```
+```fsharp
 cli {
     Exec "cmd.exe"
     Verb "runas"
+}
+|> Command.execute
+```
+
+Add environment variables for the executing program e.g.:
+```fsharp
+cli {
+    Exec "git"
+    EnvironmentVariables [("GIT_AUTHOR_NAME", "Jon Doe");("GIT_AUTHOR_EMAIL", "jon.doe@domain.com")]
 }
 |> Command.execute
 ```

--- a/src/Fli.Tests/CommandContext/CliCommandConfigTests.fs
+++ b/src/Fli.Tests/CommandContext/CliCommandConfigTests.fs
@@ -27,3 +27,21 @@ let ``Check WorkingDirectory config`` () =
     }
     |> fun c -> c.config.WorkingDirectory
     |> should equal (Some @"C:\Users")
+
+[<Test>]
+let ``Check EnvironmentVariables with single KeyValue config`` () =
+    cli {
+        Shell BASH
+        EnvironmentVariable("user", "admin")
+    }
+    |> fun c -> c.config.EnvironmentVariables.Value
+    |> should equal [ ("user", "admin") ]
+
+[<Test>]
+let ``Check EnvironmentVariables with multiple KeyValues config`` () =
+    cli {
+        Shell BASH
+        EnvironmentVariables [ ("user", "admin"); ("path", "path/to/file") ]
+    }
+    |> fun c -> c.config.EnvironmentVariables.Value
+    |> should equal [ ("user", "admin"); ("path", "path/to/file") ]

--- a/src/Fli.Tests/Fli.Tests.fsproj
+++ b/src/Fli.Tests/Fli.Tests.fsproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CommandContext\CliCommandConfigTests.fs" />
+    <Compile Include="ProgramContext\ProgramCommandConfigTests.fs" />
     <Compile Include="ProgramContext\ProgramCommandToStringTests.fs" />
     <Compile Include="ProgramContext\ProgramCommandExecuteTests.fs" />
-    <Compile Include="ProgramContext\ProgramCommandConfigTests.fs" />
     <Compile Include="CommandContext\CliCommandExecuteTests.fs" />
     <Compile Include="CommandContext\CliCommandToStringTests.fs" />
     <None Include="paket.references" />

--- a/src/Fli.Tests/ProgramContext/ProgramCommandConfigTests.fs
+++ b/src/Fli.Tests/ProgramContext/ProgramCommandConfigTests.fs
@@ -66,3 +66,21 @@ let ``Check credentials config for executing program with NetworkCredentials`` (
     }
     |> fun c -> c.config.UserName.Value
     |> should equal "admin@company"
+
+[<Test>]
+let ``Check EnvironmentVariables with single KeyValue config`` () =
+    cli {
+        Exec "cmd.exe"
+        EnvironmentVariable("user", "admin")
+    }
+    |> fun c -> c.config.EnvironmentVariables.Value
+    |> should equal [ ("user", "admin") ]
+
+[<Test>]
+let ``Check EnvironmentVariables with multiple KeyValues config`` () =
+    cli {
+        Exec "cmd.exe"
+        EnvironmentVariables [ ("user", "admin"); ("path", "path/to/file") ]
+    }
+    |> fun c -> c.config.EnvironmentVariables.Value
+    |> should equal [ ("user", "admin"); ("path", "path/to/file") ]

--- a/src/Fli/CE.fs
+++ b/src/Fli/CE.fs
@@ -43,6 +43,14 @@ module CE =
         member this.WorkingDirectory(context: ICommandContext<ShellContext>, workingDirectory) =
             Cli.workingDirectory workingDirectory context.Context
 
+        [<CustomOperation("EnvironmentVariable")>]
+        member this.EnvironmentVariable(context: ICommandContext<ShellContext>, environmentVariable) =
+            Cli.environmentVariables [ environmentVariable ] context.Context
+
+        [<CustomOperation("EnvironmentVariables")>]
+        member this.EnvironmentVariables(context: ICommandContext<ShellContext>, environmentVariables) =
+            Cli.environmentVariables environmentVariables context.Context
+
     /// Extensions for Exec context
     type ICommandContext<'a> with
 
@@ -64,3 +72,11 @@ module CE =
         [<CustomOperation("Username")>]
         member this.UserName(context: ICommandContext<ProgramContext>, userName) =
             Program.userName userName context.Context
+
+        [<CustomOperation("EnvironmentVariable")>]
+        member this.EnvironmentVariable(context: ICommandContext<ProgramContext>, environmentVariable) =
+            Program.environmentVariables [ environmentVariable ] context.Context
+
+        [<CustomOperation("EnvironmentVariables")>]
+        member this.EnvironmentVariables(context: ICommandContext<ProgramContext>, environmentVariables) =
+            Program.environmentVariables environmentVariables context.Context

--- a/src/Fli/Cli.fs
+++ b/src/Fli/Cli.fs
@@ -13,6 +13,9 @@ module Cli =
     let workingDirectory (workingDirectory: string) (context: ShellContext) =
         { context with config = { context.config with WorkingDirectory = Some workingDirectory } }
 
+    let environmentVariables (variables: (string * string) list) (context: ShellContext) =
+        { context with config = { context.config with EnvironmentVariables = Some variables } }
+
 module Program =
 
     let program (program: string) (config: Config) : ProgramContext =
@@ -29,3 +32,6 @@ module Program =
 
     let userName (userName: string) (context: ProgramContext) =
         { context with config = { context.config with UserName = Some userName } }
+
+    let environmentVariables (variables: (string * string) list) (context: ProgramContext) =
+        { context with config = { context.config with EnvironmentVariables = Some variables } }

--- a/src/Fli/Command.fs
+++ b/src/Fli/Command.fs
@@ -38,11 +38,19 @@ module Command =
             |> ArgumentException
             |> raise
 
+    let private addEnvironmentVariables (variables: (string * string) list option) (psi: ProcessStartInfo) =
+        match variables with
+        | Some (v) -> v |> List.iter (psi.Environment.Add)
+        | None -> ()
+
+        psi
+
     type Command =
         static member execute(context: ShellContext) =
             let (proc, flag) = context.config.Shell |> shellToProcess
 
             (createProcess proc $"{flag} {context.config.Command}" context.config.WorkingDirectory None None)
+            |> addEnvironmentVariables context.config.EnvironmentVariables
             |> startProcess
 
         static member toString(context: ShellContext) =
@@ -60,6 +68,7 @@ module Command =
                 context.config.WorkingDirectory
                 context.config.Verb
                 context.config.UserName)
+            |> addEnvironmentVariables context.config.EnvironmentVariables
             |> startProcess
 
         static member toString(context: ProgramContext) =

--- a/src/Fli/Domain.fs
+++ b/src/Fli/Domain.fs
@@ -9,7 +9,8 @@ module Domain =
     type ShellConfig =
         { Shell: Shells
           Command: string
-          WorkingDirectory: string option }
+          WorkingDirectory: string option
+          EnvironmentVariables: (string * string) list option }
 
     and Shells =
         | CMD
@@ -22,7 +23,8 @@ module Domain =
           Arguments: string option
           WorkingDirectory: string option
           Verb: string option
-          UserName: string option }
+          UserName: string option
+          EnvironmentVariables: (string * string) list option }
 
     type Config =
         { ShellConfig: ShellConfig
@@ -44,10 +46,12 @@ module Domain =
         { ShellConfig =
             { Shell = CMD
               Command = ""
-              WorkingDirectory = None }
+              WorkingDirectory = None
+              EnvironmentVariables = None }
           ProgramConfig =
             { Program = ""
               Arguments = None
               WorkingDirectory = None
               Verb = None
-              UserName = None } }
+              UserName = None
+              EnvironmentVariables = None } }


### PR DESCRIPTION
Adds single tuple:
`EnvironmentVariable (key, value)`
and multiple tuples:
`EnvironmentVariables [(key1, value1); (key2, value2)]`
to the underlaying (starting child) process.

Closes #7 with both `ShellContext` and `ProgramContext`.