### PR TITLE
Add StandardError support. Return errors in `Output.Error`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,12 @@ cli {
 ```
 
 #### `Command.execute`
-`Command.execute` returns record: `type Output = { Text: string; ExitCode: int }`
+`Command.execute` returns record: `type Output = { Text: string option; ExitCode: int; Error: string option }`
 which has getter methods to get only one value:
 ```fsharp
 toText: Output -> string
 toExitCode: Output -> int
+toError: Output -> string
 ```
 example:
 ```fsharp
@@ -96,13 +97,19 @@ cli {
     Shell CMD
     Command "echo Hello World!"
 }
-|> Command.execute // { Text = "Hello World!"; ExitCode = 0 }
+|> Command.execute // { Text = Some "Hello World!"; ExitCode = 0; Error = None }
 |> Output.toText // "Hello World!"
 
 // same with Output.toExitCode:
 cli { ... }
-|> Command.execute // { Text = "Hello World!"; ExitCode = 0 }
+|> Command.execute // { Text = Some "Hello World!"; ExitCode = 0; Error = None }
 |> Output.toExitCode // 0
+
+// in case of an error:
+cli { ... }
+|> Command.execute // { Text = None; ExitCode = 1; Error = Some "This is an error!" }
+|> Output.toError // "This is an error!"
+
 ```
 
 #### `Command.toString`

--- a/src/Fli.Tests/ExecContext/ExecCommandExecuteTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecCommandExecuteTests.fs
@@ -19,22 +19,20 @@ let ``Hello World with executing program`` () =
     else
         Assert.Pass()
 
-
 [<Test>]
 let ``Hello World with executing program async`` () =
     if OperatingSystem.IsWindows() then
         async {
-            let! output = 
+            let! output =
                 cli {
                     Exec "cmd.exe"
                     Arguments "/C echo Hello World!"
                 }
                 |> Command.executeAsync
 
-            output 
-            |> Output.toText
-            |> should equal "Hello World!\r\n"
-        } |> Async.Start
+            output |> Output.toText |> should equal "Hello World!\r\n"
+        }
+        |> Async.Start
     else
         Assert.Pass()
 

--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -9,13 +9,15 @@ open System
 [<Test>]
 let ``Hello World with CMD`` () =
     if OperatingSystem.IsWindows() then
-        cli {
-            Shell CMD
-            Command "echo Hello World!"
-        }
-        |> Command.execute
-        |> Output.toText
-        |> should equal "Hello World!\r\n"
+        let operation =
+            cli {
+                Shell CMD
+                Command "echo Hello World!"
+            }
+            |> Command.execute
+
+        operation |> Output.toText |> should equal "Hello World!\r\n"
+        operation |> Output.toError |> should equal ""
     else
         Assert.Pass()
 
@@ -42,6 +44,21 @@ let ``CMD returning error message`` () =
         |> Command.execute
         |> Output.toError
         |> should not' (equal None)
+    else
+        Assert.Pass()
+
+[<Test>]
+let ``CMD returning error message without text`` () =
+    if OperatingSystem.IsWindows() then
+        let operation =
+            cli {
+                Shell CMD
+                Command "echl Test"
+            }
+            |> Command.execute
+
+        operation |> Output.toError |> should not' (equal None)
+        operation |> Output.toText |> should equal ""
     else
         Assert.Pass()
 
@@ -93,7 +110,7 @@ let ``BASH returning None on ErrorMessage when there's no error`` () =
         }
         |> Command.execute
         |> Output.toError
-        |> should equal None
+        |> should equal ""
     else
         Assert.Pass()
 

--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -33,6 +33,19 @@ let ``CMD returning non zero ExitCode`` () =
         Assert.Pass()
 
 [<Test>]
+let ``CMD returning error message`` () =
+    if OperatingSystem.IsWindows() then
+        cli {
+            Shell CMD
+            Command "echl Test"
+        }
+        |> Command.execute
+        |> Output.toError
+        |> should not' (equal None)
+    else
+        Assert.Pass()
+
+[<Test>]
 let ``Hello World with PS`` () =
     if OperatingSystem.IsWindows() then
         cli {
@@ -72,6 +85,19 @@ let ``Hello World with BASH`` () =
         Assert.Pass()
 
 [<Test>]
+let ``BASH returning None on ErrorMessage when there's no error`` () =
+    if OperatingSystem.IsWindows() |> not then
+        cli {
+            Shell BASH
+            Command "\"echo Test\""
+        }
+        |> Command.execute
+        |> Output.toError
+        |> should equal None
+    else
+        Assert.Pass()
+
+[<Test>]
 let ``Hello World with BASH async`` () =
     if OperatingSystem.IsWindows() |> not then
         async {
@@ -81,11 +107,10 @@ let ``Hello World with BASH async`` () =
                     Command "\"echo Hello World!\""
                 }
                 |> Command.executeAsync
-        
-            output
-            |> Output.toText
-            |> should equal "Hello World!\n"
-        } |> Async.Start
+
+            output |> Output.toText |> should equal "Hello World!\n"
+        }
+        |> Async.Start
     else
         Assert.Pass()
 

--- a/src/Fli/Command.fs
+++ b/src/Fli/Command.fs
@@ -44,7 +44,7 @@ module Command =
             proc.WaitForExitAsync() |> ignore
 
             return
-                { Text = text
+                { Text = text |> toOption
                   ExitCode = proc.ExitCode
                   Error = error |> toOption }
         }
@@ -59,7 +59,7 @@ module Command =
         let error = proc.StandardError.ReadToEnd()
         proc.WaitForExit()
 
-        { Text = text
+        { Text = text |> toOption
           ExitCode = proc.ExitCode
           Error = error |> toOption }
 

--- a/src/Fli/Domain.fs
+++ b/src/Fli/Domain.fs
@@ -65,12 +65,12 @@ module Domain =
               Encoding = None } }
 
     type Output =
-        { Text: string
+        { Text: string option
           ExitCode: int
           Error: string option }
 
-        static member toText(output: Output) = output.Text
+        static member toText(output: Output) = output.Text |> Option.defaultValue ""
 
         static member toExitCode(output: Output) = output.ExitCode
 
-        static member toError(output: Output) = output.Error
+        static member toError(output: Output) = output.Error |> Option.defaultValue ""

--- a/src/Fli/Domain.fs
+++ b/src/Fli/Domain.fs
@@ -66,8 +66,11 @@ module Domain =
 
     type Output =
         { Text: string
-          ExitCode: int }
+          ExitCode: int
+          Error: string option }
 
         static member toText(output: Output) = output.Text
 
         static member toExitCode(output: Output) = output.ExitCode
+
+        static member toError(output: Output) = output.Error


### PR DESCRIPTION
- of course `Output.toError: Output -> string` as convinient member is available
- type of `Output.Text` changes to `string option`
- only one of `Output.Text` and `Output.Error` can be filled

Closes #17.