### PR TITLE
Add interactive input support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ cli {
 |> Command.toString // "cmd.exe /C echo Hello World!"
 ```
 
-### Implementations
-
 #### Builder operations:
 
 `ShellContext` operations (`cli { Shell ... }`):
@@ -139,29 +137,34 @@ cli {
 |------------------------|--------------------------|
 | `Shell`                | `Fli.Shells`             |
 | `Command`              | `string`                 |
+| `Input`                | `string`                 |
 | `WorkingDirectory`     | `string`                 |
 | `EnvironmentVariable`  | `string * string`        |
 | `EnvironmentVariables` | `(string * string) list` |
 | `Encoding`             | `System.Text.Encoding`   |
 
 `ExecContext` operations (`cli { Exec ... }`):
-| Operation              |  Type                      |
-|------------------------|----------------------------|
-| `Exec`                 | `string`                   |
+| Operation              |  Type                                                    |
+|------------------------|----------------------------------------------------------|
+| `Exec`                 | `string`                                                 |
 | `Arguments`            | `string` / `string seq` / `string list` / `string array` |
-| `Verb`                 | `string`                   |
-| `Username`             | `string`                   |
-| `Credentials`          | `string * string * string` |
-| `WorkingDirectory`     | `string`                   |
-| `EnvironmentVariable`  | `string * string`          |
-| `EnvironmentVariables` | `(string * string) list`   |
-| `Encoding`             | `System.Text.Encoding`     |
+| `Input`                | `string`                                                 |
+| `Verb`                 | `string`                                                 |
+| `Username`             | `string`                                                 |
+| `Credentials`          | `string * string * string`                               |
+| `WorkingDirectory`     | `string`                                                 |
+| `EnvironmentVariable`  | `string * string`                                        |
+| `EnvironmentVariables` | `(string * string) list`                                 |
+| `Encoding`             | `System.Text.Encoding`                                   |
 
 Currently provided `Fli.Shells`:
-- `CMD` runs `cmd.exe /C ...`
+- `CMD` runs `cmd.exe /c ...` or `cmd.exe /k ...` (depends if `Input` is provided or not)
 - `PS` runs `powershell.exe -Command ...`
 - `PWSH` runs `pwsh.exe -Command ...`
-- `BASH` runs `bash -c ..`
+- `BASH` runs `bash -c ...`
+
+### Something's missing?
+Don't hesitate to open an [issue](https://github.com/CaptnCodr/Fli/issues) or start a [discussion](https://github.com/CaptnCodr/Fli/discussions).
 
 ### Inspiration
 Use CE's for command line interface commands came in mind while using [FsHttp](https://github.com/fsprojects/FsHttp).

--- a/src/Fli.Tests/ExecContext/ExecCommandConfigureTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecCommandConfigureTests.fs
@@ -113,6 +113,7 @@ let ``Check all possible values in ProcessStartInfo for windows`` () =
             cli {
                 Exec "cmd.exe"
                 Arguments "--help"
+                Input "Test"
                 WorkingDirectory @"C:\Users"
                 Verb "open"
                 Username "admin"

--- a/src/Fli.Tests/ExecContext/ExecCommandExecuteTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecCommandExecuteTests.fs
@@ -20,6 +20,21 @@ let ``Hello World with executing program`` () =
         Assert.Pass()
 
 [<Test>]
+let ``print text with Input with executing program`` () =
+    if OperatingSystem.IsWindows() then
+        cli {
+            Exec "cmd.exe"
+            Arguments "/k echo Test"
+            Input "echo Hello World!"
+            WorkingDirectory @"C:\"
+        }
+        |> Command.execute
+        |> Output.toText
+        |> should equal "Test\r\n\r\nC:\\>echo Hello World!\r\nHello World!\r\n\r\nC:\\>"
+    else
+        Assert.Pass()
+
+[<Test>]
 let ``Hello World with executing program async`` () =
     if OperatingSystem.IsWindows() then
         async {

--- a/src/Fli.Tests/ExecContext/ExecConfigTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecConfigTests.fs
@@ -18,7 +18,6 @@ let ``Check arguments config for executing program`` () =
     |> fun c -> c.config.Arguments
     |> should equal (Some "echo Hello World!")
 
-
 [<Test>]
 let ``Check arguments list config for executing program`` () =
     cli {
@@ -27,6 +26,15 @@ let ``Check arguments list config for executing program`` () =
     }
     |> fun c -> c.config.Arguments
     |> should equal (Some "echo Hello World!")
+
+[<Test>]
+let ``Check Input config for executing program`` () =
+    cli {
+        Exec "cmd.exe"
+        Input "echo 123\r\necho Test"
+    }
+    |> fun c -> c.config.Input
+    |> should equal (Some "echo 123\r\necho Test")
 
 [<Test>]
 let ``Check working directory config for executing program`` () =

--- a/src/Fli.Tests/ShellContext/ShellCommandConfigureTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandConfigureTests.fs
@@ -74,6 +74,7 @@ let ``Check all possible values in ProcessStartInfo`` () =
         cli {
             Shell BASH
             Command "echo Hello World! €"
+            Input "echo TestInput"
             WorkingDirectory @"C:\Users"
             EnvironmentVariable("Fli", "test")
             EnvironmentVariables [ ("Fli.Test", "test") ]

--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -35,6 +35,20 @@ let ``CMD returning non zero ExitCode`` () =
         Assert.Pass()
 
 [<Test>]
+let ``Text in Input with CMD`` () =
+    if OperatingSystem.IsWindows() then
+        cli {
+            Shell CMD
+            Input "echo 123\r\necho 345"
+            WorkingDirectory @"C:\"
+        }
+        |> Command.execute
+        |> Output.toText
+        |> should equal "C:\\>echo 123\r\n123\r\n\r\nC:\\>echo 345\r\n345\r\n\r\nC:\\>"
+    else
+        Assert.Pass()
+
+[<Test>]
 let ``CMD returning error message`` () =
     if OperatingSystem.IsWindows() then
         cli {
@@ -102,15 +116,16 @@ let ``Hello World with BASH`` () =
         Assert.Pass()
 
 [<Test>]
-let ``BASH returning None on ErrorMessage when there's no error`` () =
+let ``Input text in BASH`` () =
     if OperatingSystem.IsWindows() |> not then
         cli {
             Shell BASH
-            Command "\"echo Test\""
+            Command "\"echo Hello World!\""
+            Input "\"echo Test\""
         }
         |> Command.execute
-        |> Output.toError
-        |> should equal ""
+        |> Output.toText
+        |> should equal "Hello World!\n"
     else
         Assert.Pass()
 

--- a/src/Fli.Tests/ShellContext/ShellCommandToStringTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandToStringTests.fs
@@ -12,7 +12,17 @@ let ``CMD command toString returns full line`` () =
         Command "echo Hello World!"
     }
     |> Command.toString
-    |> should equal "cmd.exe /C echo Hello World!"
+    |> should equal "cmd.exe /c echo Hello World!"
+
+[<Test>]
+let ``CMD command toString returns full line in interactive mode`` () =
+    cli {
+        Shell CMD
+        Command "echo Hello World!"
+        Input "echo Hello World!"
+    }
+    |> Command.toString
+    |> should equal "cmd.exe /k echo Hello World!"
 
 [<Test>]
 let ``PS command toString returns full line`` () =

--- a/src/Fli.Tests/ShellContext/ShellConfigTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellConfigTests.fs
@@ -16,7 +16,16 @@ let ``Check Command config`` () =
         Command "echo test"
     }
     |> fun c -> c.config.Command
-    |> should equal "echo test"
+    |> should equal (Some "echo test")
+
+[<Test>]
+let ``Check Input config for CMD`` () =
+    cli {
+        Shell CMD
+        Input "echo 123\r\necho Test"
+    }
+    |> fun c -> c.config.Input
+    |> should equal (Some "echo 123\r\necho Test")
 
 [<Test>]
 let ``Check WorkingDirectory config`` () =

--- a/src/Fli/CE.fs
+++ b/src/Fli/CE.fs
@@ -29,6 +29,9 @@ module CE =
         [<CustomOperation("Command")>]
         member this.Command(context: ICommandContext<ShellContext>, command) = Cli.command command context.Context
 
+        [<CustomOperation("Input")>]
+        member this.Input(context: ICommandContext<ShellContext>, input) = Cli.input input context.Context
+
         [<CustomOperation("WorkingDirectory")>]
         member this.WorkingDirectory(context: ICommandContext<ShellContext>, workingDirectory) =
             Cli.workingDirectory workingDirectory context.Context
@@ -60,6 +63,9 @@ module CE =
                 | _ -> failwith "Cannot convert arguments to a string!"
 
             Program.arguments (matchArguments arguments) context.Context
+
+        [<CustomOperation("Input")>]
+        member this.Input(context: ICommandContext<ExecContext>, input) = Program.input input context.Context
 
         [<CustomOperation("WorkingDirectory")>]
         member this.WorkingDirectory(context: ICommandContext<ExecContext>, workingDirectory) =

--- a/src/Fli/Domain.fs
+++ b/src/Fli/Domain.fs
@@ -8,7 +8,8 @@ module Domain =
 
     type ShellConfig =
         { Shell: Shells
-          Command: string
+          Command: string option
+          Input: string option
           WorkingDirectory: string option
           EnvironmentVariables: (string * string) list option
           Encoding: System.Text.Encoding option }
@@ -22,6 +23,7 @@ module Domain =
     type ExecConfig =
         { Program: string
           Arguments: string option
+          Input: string option
           WorkingDirectory: string option
           Verb: string option
           UserName: string option
@@ -50,13 +52,15 @@ module Domain =
     let Defaults =
         { ShellConfig =
             { Shell = CMD
-              Command = ""
+              Command = None
+              Input = None
               WorkingDirectory = None
               EnvironmentVariables = None
               Encoding = None }
           ExecConfig =
             { Program = ""
               Arguments = None
+              Input = None
               WorkingDirectory = None
               Verb = None
               UserName = None

--- a/src/Fli/Dsl.fs
+++ b/src/Fli/Dsl.fs
@@ -8,7 +8,10 @@ module Cli =
         { config = { config.ShellConfig with Shell = shell } }
 
     let command (command: string) (context: ShellContext) =
-        { context with config = { context.config with Command = command } }
+        { context with config = { context.config with Command = Some command } }
+
+    let input (input: string) (context: ShellContext) =
+        { context with config = { context.config with Input = Some input } }
 
     let workingDirectory (workingDirectory: string) (context: ShellContext) =
         { context with config = { context.config with WorkingDirectory = Some workingDirectory } }
@@ -31,6 +34,9 @@ module Program =
 
     let arguments (arguments: string) (context: ExecContext) =
         { context with config = { context.config with Arguments = Some arguments } }
+
+    let input (input: string) (context: ExecContext) =
+        { context with config = { context.config with Input = Some input } }
 
     let workingDirectory (workingDirectory: string) (context: ExecContext) =
         { context with config = { context.config with WorkingDirectory = Some workingDirectory } }


### PR DESCRIPTION
- with native `CMD` interactive mode `cmd.exe /k`

Closes #18.