### PR TITLE
`Command.ExecuteAsync` stdout and stderr content now gets returned

### DIFF
--- a/src/Fli.Tests/ExecContext/ExecCommandExecuteTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecCommandExecuteTests.fs
@@ -107,9 +107,9 @@ let ``Hello World with executing program async`` () =
 
             output |> Output.toText |> should equal "Hello World!"
         }
-        |> Async.Start
     else
         Assert.Pass()
+        |> async.Return
 
 [<Test>]
 let ``Hello World with executing program with Verb`` () =

--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -5,8 +5,6 @@ open FsUnit
 open Fli
 open System
 open System.Text
-open System.Runtime.CompilerServices
-open System.Threading
 open System.Diagnostics
 
 

--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -231,9 +231,9 @@ let ``Hello World with BASH async`` () =
 
             output |> Output.toText |> should equal "Hello World!"
         }
-        |> Async.Start
     else
         Assert.Pass()
+        |> async.Return 
 
 [<Test>]
 let ``BASH returning non zero ExitCode`` () =

--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -27,31 +27,30 @@ let ``Hello World with CMD`` () =
 
 [<Test>]
 let ``Hello World with CMD waiting async`` () =
-    async {
         if OperatingSystem.IsWindows() then
-            let stopwatch = new Stopwatch()
-            stopwatch.Start()
+            async {
+                let stopwatch = new Stopwatch()
+                stopwatch.Start()
 
-            try
-                let! operation =
-                    cli {
-                        Shell(CUSTOM("cmd.exe", "/K"))
-                        Command "Hello World!"
-                        CancelAfter 3000
-                    }
-                    |> Command.executeAsync
-                    |> Async.StartAsTask
-                    |> Async.AwaitTask
+                try
+                    let! operation =
+                        cli {
+                            Shell(CUSTOM("cmd.exe", "/K"))
+                            Command "Hello World!"
+                            CancelAfter 3000
+                        }
+                        |> Command.executeAsync
 
-                ()
-            with :? AggregateException as e ->
-                e.GetType() |> should equal typeof<AggregateException>
+                    ()
+                with :? AggregateException as e ->
+                    e.GetType() |> should equal typeof<AggregateException>
 
-            stopwatch.Stop()
-            stopwatch.Elapsed.TotalSeconds |> should be (inRange 2.9 3.2)
+                stopwatch.Stop()
+                stopwatch.Elapsed.TotalSeconds |> should be (inRange 2.9 3.2)
+            }
         else
             Assert.Pass()
-    }
+            |> async.Return
 
 [<Test>]
 let ``Hello World with CUSTOM shell`` () =

--- a/src/Fli/Command.fs
+++ b/src/Fli/Command.fs
@@ -53,7 +53,7 @@ module Command =
         async {
             let proc = Process.Start(startInfo = psi)
             do! proc |> inFunc |> Async.AwaitTask
-            
+
             let sbStd = StringBuilder()
             let sbErr = StringBuilder()
 


### PR DESCRIPTION
This is an initial attempt at fixing the `Command.ExecuteAsync` not properly returning the the stdout content. I have updated the tests to return `Async<Unit>` so the results are awaited.

Fixes #57