### PR TITLE
add sh and zsh, add Linux's pwsh, always quote default shell

### DIFF
--- a/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandExecuteTests.fs
@@ -62,7 +62,7 @@ let ``Hello World with CUSTOM shell`` () =
     else
         cli {
             Shell(CUSTOM("bash", "-c"))
-            Command "\"echo Hello World!\""
+            Command "echo Hello World!"
         }
         |> Command.execute
         |> Output.toText

--- a/src/Fli/Command.fs
+++ b/src/Fli/Command.fs
@@ -19,7 +19,9 @@ module Command =
         | PS -> "powershell.exe", "-Command"
         | PWSH -> "pwsh.exe", "-Command"
         | WSL -> "wsl.exe", "--"
+        | SH -> "sh", "-c"
         | BASH -> "bash", "-c"
+        | ZSH -> "zsh", "-c"
         | CUSTOM(shell, flag) -> shell, flag
 
     let private toOption =

--- a/src/Fli/Command.fs
+++ b/src/Fli/Command.fs
@@ -13,11 +13,17 @@ module Command =
     open System.Runtime.InteropServices
     open System.Threading
 
+    let private getAvailablePwshExe () =
+        if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+            "pwsh.exe"
+        else
+            "pwsh"
+
     let private shellToProcess (shell: Shells) (input: string option) =
         match shell with
         | CMD -> "cmd.exe", (if input.IsNone then "/c" else "/k")
         | PS -> "powershell.exe", "-Command"
-        | PWSH -> "pwsh.exe", "-Command"
+        | PWSH -> getAvailablePwshExe (), "-Command"
         | WSL -> "wsl.exe", "--"
         | SH -> "sh", "-c"
         | BASH -> "bash", "-c"

--- a/src/Fli/Command.fs
+++ b/src/Fli/Command.fs
@@ -202,9 +202,16 @@ module Command =
         cts.Token
 
     let private quoteBashCommand (context: ShellContext) =
-        match context.config.Shell with
-        | Shells.BASH -> context.config.Command |> Option.defaultValue "" |> (fun s -> $"\"{s}\"")
-        | _ -> context.config.Command |> Option.defaultValue ""
+        let noQuoteNeeded = [|
+            Shells.CMD
+            Shells.PWSH
+            Shells.PS
+            Shells.WSL
+        |]
+
+        match Array.contains context.config.Shell noQuoteNeeded with
+        | true -> context.config.Command |> Option.defaultValue ""
+        | false -> context.config.Command |> Option.defaultValue "" |> (fun s -> $"\"{s}\"")
 
     let private getProcessWindowStyle (windowStyle: WindowStyle) =
         match windowStyle with

--- a/src/Fli/Domain.fs
+++ b/src/Fli/Domain.fs
@@ -25,7 +25,9 @@ module Domain =
         | PS
         | PWSH
         | WSL
+        | SH
         | BASH
+        | ZSH
         | CUSTOM of shell: string * flag: string
 
     and Outputs =


### PR DESCRIPTION
This PR introduces a breaking change to always quote Command passed to a custom shell.
Comments and discussion welcome.