### PR TITLE
Empty file output will not write to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ Add environment variables for the executing program:
 cli {
     Exec "git"
     EnvironmentVariables [("GIT_AUTHOR_NAME", "Jon Doe"); ("GIT_AUTHOR_EMAIL", "jon.doe@domain.com")]
+    Output ""
 }
 |> Command.execute
 ```
+Hint: `Output ""` will be ignored. This is for conditional cases, e.g.: `Output (if true then logFilePath else "")`.
 
 Add credentials to program:
 ```fsharp
@@ -127,8 +129,8 @@ cli {
 For Windows applications it's possible to set their visibility. There are four possible values: `Hidden`, `Maximized`, `Minimized` and `Normal`. The default is `Hidden`.
 ```fsharp
 cli {
-        Exec @"C:\Windows\regedit.exe"
-        WindowStyle Normal
+    Exec @"C:\Windows\regedit.exe"
+    WindowStyle Normal
 }
 |> Command.execute
 ```
@@ -278,7 +280,7 @@ Currently provided `Fli.Shells`:
 - `ZSH` runs `zsh -c ...`
 - `CUSTOM (shell: string * flag: string)` runs the specified `shell` with the specified starting argument (`flag`)
 
-Provided `Fli.Outputs`:
+Provided `Fli.Outputs`:~~~~
 - `File of string` a string with an absolute path of the output file.
 - `StringBuilder of StringBuilder` a StringBuilder which will be filled with the output text.
 - `Custom of Func<string, unit>` a custom function (`string -> unit`) that will be called with the output string (logging, printing etc.).

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Currently provided `Fli.Shells`:
 - `ZSH` runs `zsh -c ...`
 - `CUSTOM (shell: string * flag: string)` runs the specified `shell` with the specified starting argument (`flag`)
 
-Provided `Fli.Outputs`:~~~~
+Provided `Fli.Outputs`:
 - `File of string` a string with an absolute path of the output file.
 - `StringBuilder of StringBuilder` a StringBuilder which will be filled with the output text.
 - `Custom of Func<string, unit>` a custom function (`string -> unit`) that will be called with the output string (logging, printing etc.).

--- a/src/Fli.Tests/ExecContext/ExecCommandConfigureUnixTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecCommandConfigureUnixTests.fs
@@ -12,7 +12,7 @@ open System.Text
 let ``Check FileName in ProcessStartInfo Exec program`` () =
     cli { Exec "bash" }
     |> Command.buildProcess
-    |> (fun p -> p.FileName)
+    |> _.FileName
     |> should equal "bash"
 
 [<Test>]

--- a/src/Fli.Tests/ExecContext/ExecCommandConfigureWindowsTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecCommandConfigureWindowsTests.fs
@@ -12,7 +12,7 @@ open System.Text
 let ``Check FileName in ProcessStartInfo Exec program`` () =
     cli { Exec "cmd.exe" }
     |> Command.buildProcess
-    |> (fun p -> p.FileName)
+    |> _.FileName
     |> should equal "cmd.exe"
 
 [<Test>]

--- a/src/Fli.Tests/ExecContext/ExecConfigTests.fs
+++ b/src/Fli.Tests/ExecContext/ExecConfigTests.fs
@@ -46,6 +46,22 @@ let ``Check Output config for executing program`` () =
     |> should equal (Some(File @"C:\Users\test.txt"))
 
 [<Test>]
+let ``Empty string in Output ends up as None`` () =
+    cli {
+        Exec "cmd.exe"
+        Output ""
+    }
+    |> _.config.Output |> should be (ofCase <@ None @>)
+
+[<Test>]
+let ``Nullable file path in Output ends up as None`` () =
+    cli {
+        Exec "cmd.exe"
+        Output (File(null))
+    }
+    |> _.config.Output |> should be (ofCase <@ None @>)
+
+[<Test>]
 let ``Check working directory config for executing program`` () =
     cli {
         Exec "cmd.exe"
@@ -55,7 +71,7 @@ let ``Check working directory config for executing program`` () =
     |> should equal (Some @"C:\Users")
 
 [<Test>]
-let ``Check windowstyle config for executing program`` () =
+let ``Check WindowStyle config for executing program`` () =
     cli {
         Exec "cmd.exe"
         WindowStyle Normal }

--- a/src/Fli.Tests/ShellContext/ShellCommandConfigureUnixTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandConfigureUnixTests.fs
@@ -12,7 +12,7 @@ open System.Text
 let ``Check FileName in ProcessStartInfo with CMD Shell`` () =
     cli { Shell BASH }
     |> Command.buildProcess
-    |> (fun p -> p.FileName)
+    |> _.FileName
     |> should equal "bash"
 
 [<Test>]

--- a/src/Fli.Tests/ShellContext/ShellCommandConfigureWindowsTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellCommandConfigureWindowsTests.fs
@@ -12,7 +12,7 @@ open System.Text
 let ``Check FileName in ProcessStartInfo with CMD Shell`` () =
     cli { Shell CMD }
     |> Command.buildProcess
-    |> (fun p -> p.FileName)
+    |> _.FileName
     |> should equal "cmd.exe"
 
 [<Test>]

--- a/src/Fli.Tests/ShellContext/ShellConfigTests.fs
+++ b/src/Fli.Tests/ShellContext/ShellConfigTests.fs
@@ -37,6 +37,22 @@ let ``Check Output config for CMD`` () =
     |> should equal (Some(File @"C:\Users\test.txt"))
 
 [<Test>]
+let ``Empty string in Output ends up as None`` () =
+    cli {
+        Shell CMD
+        Output ""
+    }
+    |> _.config.Output |> should be (ofCase <@ None @>)
+
+[<Test>]
+let ``Nullable file path in Output ends up as None`` () =
+    cli {
+        Shell CMD
+        Output (File(null))
+    }
+    |> _.config.Output |> should be (ofCase <@ None @>)
+
+[<Test>]
 let ``Check WorkingDirectory config`` () =
     cli {
         Shell BASH

--- a/src/Fli/CE.fs
+++ b/src/Fli/CE.fs
@@ -8,7 +8,7 @@ module CE =
 
     type ICommandContext<'a> with
 
-        member this.Yield(_) = this
+        member this.Yield _ = this
 
     type StartingContext =
         { config: Config option }
@@ -35,6 +35,11 @@ module CE =
         /// `Input` string(s) that can be used to interact with the shell.
         [<CustomOperation("Input")>]
         member _.Input(context: ICommandContext<ShellContext>, input) = Cli.input input context.Context
+
+        /// Extra `Output` that is being executed immediately after getting output from execution.
+        [<CustomOperation("Output")>]
+        member _.Output(context: ICommandContext<ShellContext>, output: Outputs) =
+            Cli.output output context.Context
 
         /// Extra `Output` that is being executed immediately after getting output from execution.
         [<CustomOperation("Output")>]
@@ -93,7 +98,7 @@ module CE =
         [<CustomOperation("Arguments")>]
         member _.Arguments(context: ICommandContext<ExecContext>, arguments) =
             let matchArguments arguments =
-                match box (arguments) with
+                match box arguments with
                 | :? string as s -> s
                 | :? seq<string> as s -> s |> Seq.map string |> String.concat " "
                 | _ -> failwith "Cannot convert arguments to a string!"
@@ -103,6 +108,11 @@ module CE =
         /// `Input` string(s) that can be used to interact with the executable.
         [<CustomOperation("Input")>]
         member _.Input(context: ICommandContext<ExecContext>, input) = Program.input input context.Context
+
+        /// Extra `Output` that is being executed immediately after getting output from execution.
+        [<CustomOperation("Output")>]
+        member _.Output(context: ICommandContext<ExecContext>, output: Outputs) =
+            Program.output output context.Context
 
         /// Extra `Output` that is being executed immediately after getting output from execution.
         [<CustomOperation("Output")>]
@@ -143,7 +153,7 @@ module CE =
         /// Hint: `Domain` and `Password` are available for Windows systems only.
         [<CustomOperation("Credentials")>]
         member _.Credentials(context: ICommandContext<ExecContext>, credentials) =
-            let (domain, user, pw) = credentials in Program.credentials (Credentials(domain, user, pw)) context.Context
+            let domain, user, pw = credentials in Program.credentials (Credentials(domain, user, pw)) context.Context
 
         /// One tupled `EnvironmentVariable`.
         [<CustomOperation("EnvironmentVariable")>]

--- a/src/Fli/Dsl.fs
+++ b/src/Fli/Dsl.fs
@@ -1,6 +1,7 @@
 ﻿namespace Fli
 
 open Domain
+open Helpers
 
 module Cli =
 
@@ -18,8 +19,12 @@ module Cli =
             config.Input = Some input }
 
     let output (output: Outputs) (context: ShellContext) =
-        { context with
-            config.Output = Some output }
+        let outputsOption =
+            match output with
+            | File path -> path |> toOptionWithDefault output
+            | _ -> Some output
+
+        { context with config.Output = outputsOption }
 
     let workingDirectory (workingDirectory: string) (context: ShellContext) =
         { context with
@@ -62,8 +67,12 @@ module Program =
             config.Input = Some input }
 
     let output (output: Outputs) (context: ExecContext) =
-        { context with
-            config.Output = Some output }
+        let outputsOption =
+            match output with
+            | File path -> path |> toOptionWithDefault output
+            | _ -> Some output
+
+        { context with config.Output = outputsOption }
 
     let workingDirectory (workingDirectory: string) (context: ExecContext) =
         { context with

--- a/src/Fli/Fli.fsproj
+++ b/src/Fli/Fli.fsproj
@@ -21,10 +21,10 @@
     <Compile Include="AssemblyInfo.fs" />
     <Compile Include="Domain.fs" />
     <Compile Include="Output.fs" />
+    <Compile Include="Helpers.fs" />
     <Compile Include="Dsl.fs" />
     <Compile Include="CE.fs" />
     <Compile Include="Extensions.fs" />
-    <Compile Include="Helpers.fs" />
     <Compile Include="Command.fs" />
     <None Include="paket.references" />
     <None Include="paket.template" />

--- a/src/Fli/Helpers.fs
+++ b/src/Fli/Helpers.fs
@@ -24,3 +24,15 @@ module Helpers =
             secureString
         finally
             gcHandle.Free()
+
+    let toOption =
+        function
+        | null
+        | "" -> None
+        | s -> Some s
+
+    let toOptionWithDefault defaultValue value =
+        match value with
+        | null
+        | "" -> None
+        | _ -> Some defaultValue


### PR DESCRIPTION
Closes #69 

This will add the ability to have `Outputs` cases in `Fli` CE, this code is now legal:
- `Output ""`
- `Output Outputs.File(null)`
- `Output Outputs.File("")`

this will be treated the same as just not having an `Output`.